### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 env:
   LOGPATH: ${{ github.workspace }}/logs


### PR DESCRIPTION
Potential fix for [https://github.com/tknie/services/security/code-scanning/13](https://github.com/tknie/services/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to build and test the Go project. This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
